### PR TITLE
Change runtime log response codes from FOUND to OK

### DIFF
--- a/src/route.rs
+++ b/src/route.rs
@@ -64,14 +64,14 @@ pub async fn get(
 
             if name == Some(RUNTIME_CONDENSED_TXT) {
                 return Ok((
-                    StatusCode::FOUND,
+                    StatusCode::OK,
                     headers("text/plain"),
                     crate::parsers::runtimes::condense_runtimes_to_string(&runtimes_contents),
                 )
                     .into_response());
             } else if name == Some(RUNTIME_CONDENSED_JSON) {
                 return Ok((
-                    StatusCode::FOUND,
+                    StatusCode::OK,
                     headers("application/json"),
                     crate::parsers::runtimes::condense_runtimes_to_json(&runtimes_contents)
                         .to_string(),


### PR DESCRIPTION
Previously, requests to the runtime logfiles were returning with a [302](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/302) status code without the corresponding redirection headers. It should return a [200](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/200) status code instead.