### PR TITLE
Adds handling for the `profiler` subdir.

### DIFF
--- a/src/ongoing_round_protection.rs
+++ b/src/ongoing_round_protection.rs
@@ -132,15 +132,10 @@ async fn fetch_ongoing_rounds(serverinfo_url: &str) -> eyre::Result<HashMap<Stri
     };
 
     let round_ids = HashMap::from_iter(server_info.servers.into_iter().filter_map(|server| {
-        server
-            .data
-            .map(|data| match data.round_id {
-                Some(round_id) => {
-                    Some((data.identifier, round_id.parse().expect("invalid round id")))
-                }
-                None => None,
-            })
-            .flatten()
+        server.data.and_then(|data| match data.round_id {
+            Some(round_id) => Some((data.identifier, round_id.parse().expect("invalid round id"))),
+            None => None,
+        })
     }));
 
     tracing::debug!("current round ids: {round_ids:?}");

--- a/src/parsers/game.rs
+++ b/src/parsers/game.rs
@@ -12,7 +12,7 @@ macro_rules! censor {
 }
 
 #[tracing::instrument(skip_all)]
-pub fn parse_line(line: &str) -> Cow<str> {
+pub fn parse_line<'a>(line: &'a str) -> Cow<'a, str> {
     let line = line.trim();
 
     if line.is_empty() {

--- a/src/parsers/ip_filtering.rs
+++ b/src/parsers/ip_filtering.rs
@@ -6,6 +6,6 @@ static IP_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]?|[0-9])").unwrap()
 });
 
-pub fn filter_ips(contents: &str) -> Cow<str> {
+pub fn filter_ips<'a>(contents: &'a str) -> Cow<'a, str> {
     IP_REGEX.replace_all(contents, "-censored-")
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -109,6 +109,14 @@ pub fn get_file_sanitization_strategy(path: &Path) -> Option<fn(String) -> Strin
 
         perf_filename if perf_filename.starts_with("perf-") => Some(std::convert::identity),
 
+        profiler_file
+            if path
+                .parent()
+                .is_some_and(|p| p.file_name().is_some_and(|pname| pname.eq("profiler"))) =>
+        {
+            Some(std::convert::identity)
+        }
+
         _ => None,
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -112,7 +112,7 @@ pub fn get_file_sanitization_strategy(path: &Path) -> Option<fn(String) -> Strin
         profiler_file
             if path
                 .parent()
-                .is_some_and(|p| p.file_name().is_some_and(|pname| pname.eq("profiler"))) =>
+                .is_some_and(|p| p.file_name().is_some_and(|pname| pname == "profiler")) =>
         {
             Some(std::convert::identity)
         }

--- a/src/parsers/runtimes.rs
+++ b/src/parsers/runtimes.rs
@@ -13,7 +13,7 @@ pub fn process_runtimes_log(contents: String) -> String {
 }
 
 // Remove BYOND printed strings
-fn sanitize_runtimes_line(line: &str) -> Cow<str> {
+fn sanitize_runtimes_line<'a>(line: &'a str) -> Cow<'a, str> {
     static STRING_OUTPUT_REGEX: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r#"^.*Cannot read ".*$"#).unwrap());
 
@@ -101,7 +101,7 @@ struct CondensedRuntimes<'a> {
     runtimes: Vec<CondensedRuntime<'a>>,
 }
 
-fn get_condensed_runtimes(runtime_contents: &str) -> CondensedRuntimes {
+fn get_condensed_runtimes<'a>(runtime_contents: &'a str) -> CondensedRuntimes<'a> {
     let mut lines = runtime_contents.lines().peekable();
     let mut condensed_runtimes: HashMap<CondensedRuntimeKey, CondensedRuntimeValue> =
         HashMap::new();


### PR DESCRIPTION
Also adds explicit lifetimes to tell the borrow checker to shut up. (explicit carry through lifetimes)